### PR TITLE
Keys are not in the keys folder, unfortunately

### DIFF
--- a/sync-config.sh
+++ b/sync-config.sh
@@ -11,14 +11,15 @@ else
 	exit
 fi
 
-if [ ! -f /config/keys/private.key ]; then
+if [ ! -f /config/private.key ]; then
 	echo "No private key found, unable to decrypt"
 fi
-if [ ! -f /config/keys/public.key ]; then
+if [ ! -f /config/public.key ]; then
 	echo "No public key found, unable to verify signatures"
 fi
-gpg2 --import /config/keys/private.key 2>/dev/null
-gpg2 --import /config/keys/public.key 2>/dev/null
-rm -rf /config/keys
+gpg2 --import /config/private.key 2>/dev/null
+gpg2 --import /config/public.key 2>/dev/null
+rm -rf /config/private.key
+rm -rf /config/public.key
 
 # Begin decryption operations here before exiting

--- a/sync-config.sh
+++ b/sync-config.sh
@@ -13,13 +13,15 @@ fi
 
 if [ ! -f /config/private.key ]; then
 	echo "No private key found, unable to decrypt"
+else
+	gpg2 --import /config/private.key 2>/dev/null
 fi
 if [ ! -f /config/public.key ]; then
 	echo "No public key found, unable to verify signatures"
+else
+	gpg2 --import /config/public.key 2>/dev/null
 fi
-gpg2 --import /config/private.key 2>/dev/null
-gpg2 --import /config/public.key 2>/dev/null
-rm -rf /config/private.key
-rm -rf /config/public.key
+
+rm -f /config/public.key /config/private.key
 
 # Begin decryption operations here before exiting


### PR DESCRIPTION
We'd have to set up a migration if we want to have it in the keys folder; for simplicity sake just assume that the keys are where they are now.

@pebble/webops 
