### PR TITLE
Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,15 @@ ENV CONFIG_SOURCE="" \
     GOPATH=/gopath \
     GOBIN=/usr/bin
 
-ADD sync-config.sh /usr/bin/sync-config
-
 RUN apk add -U --no-cache go git gnupg && \
     go get -v github.com/ncw/rclone && \
     adduser -D orbit && \
     apk del --purge go git && \
     rm -rf /var/cache/apk && \
     rm -rf /gopath && \
-    mkdir /home/orbit/config && \
-    chmod +x /usr/bin/sync-config
+    mkdir /home/orbit/config
+
+COPY sync-config.sh /usr/bin/sync-config
 
 USER orbit
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Have all of the environment files you want made available to your app
 in a storage medium your instance can reach, defined as SOURCE_ENV.
 
 Any source files encrypted with git-deploy's 'secret' command with a .secret
-extension will arrive at the designation decrypted with extension stripped
+extension will arrive at the destination decrypted with extension stripped
 so long as the needed GPG keys are present in the SOURCE_ENV as public.key and
 private.key respectively.
 

--- a/sync-config.sh
+++ b/sync-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 [ -z "${ENV_SOURCE}" ] && echo "No ENV_SOURCE URI specified"; exit
 


### PR DESCRIPTION
- chmod +x on sync-config.sh in git (this saves a command during
  container build).
- swap internal script to using sh (bash isn't installed in the
  container?!)
- ADD script after the build RUN block for dat cache.
- COPY script instead of ADD, just a boring local file.
- Typo in README
